### PR TITLE
Hide meta tag generator for security reason

### DIFF
--- a/astroid/astroid-template-zero/index.php
+++ b/astroid/astroid-template-zero/index.php
@@ -9,6 +9,7 @@
 defined('_JEXEC') or die;
 $doc = JFactory::getDocument();
 $app = JFactory::getApplication();
+$doc->setGenerator(''); // 	hide the generator meta tag for security reason
 
 /** @var JDocumentHtml $this */
 JLoader::import('joomla.filesystem.file');


### PR DESCRIPTION
Before PR, view source page gives 	<meta name="generator" content="Joomla! - Open Source Content Management" />

After PR, this line is not displayed anymore.