### PR TITLE
Hide meta tag generator for security reason

### DIFF
--- a/astroid/astroid-template-zero/index.php
+++ b/astroid/astroid-template-zero/index.php
@@ -9,6 +9,7 @@
 defined('_JEXEC') or die;
 $doc = JFactory::getDocument();
 $app = JFactory::getApplication();
+$doc->setGenerator(''); // 	hide the meta tag generator for website security
 
 /** @var JDocumentHtml $this */
 JLoader::import('joomla.filesystem.file');


### PR DESCRIPTION
Before this PR, when looking at page source, meta tag "generator" is displayed
\<meta name="generator" content="Joomla! - Open Source Content Management" />

This PR hides this meta tag.